### PR TITLE
Ajuste ResponseBody do endpoint "/getDistricts" + Padronização do código

### DIFF
--- a/src/main/java/com/meli/w4/desafio_quality/controller/DistrictController.java
+++ b/src/main/java/com/meli/w4/desafio_quality/controller/DistrictController.java
@@ -34,7 +34,7 @@ public class DistrictController {
     @PostMapping("/registerDistrict")
     private ResponseEntity<Map<String, String>> registerDistricts(@RequestBody @Valid DistrictDTO districts, UriComponentsBuilder uriBuilder) throws IOException{
         URI uri = uriBuilder.path("/getDistricts").build().toUri();
-        return districtService.gravaBairro(districts, uri);
+        return districtService.saveDistricts(districts, uri);
     }
 
 
@@ -45,7 +45,7 @@ public class DistrictController {
      * @return ResponseEntity
      */
     @GetMapping("/getDistricts")
-    private ResponseEntity<List<District>> getDistricts() throws IOException {
+    private ResponseEntity<DistrictDTO> getDistricts() throws IOException {
         return districtService.getAllDistricts();
     }
 }

--- a/src/main/java/com/meli/w4/desafio_quality/dto/DistrictDTO.java
+++ b/src/main/java/com/meli/w4/desafio_quality/dto/DistrictDTO.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 @Builder
@@ -18,4 +19,9 @@ public class DistrictDTO {
 
     @NotEmpty(message = "A lista não pode estar vazia")
     private List<@Valid District> districts;
+
+
+    public static DistrictDTO parseToListDTO(List<District> districts){
+        return DistrictDTO.builder().districts(districts).build();
+    }
 }

--- a/src/main/java/com/meli/w4/desafio_quality/dto/DistrictDTO.java
+++ b/src/main/java/com/meli/w4/desafio_quality/dto/DistrictDTO.java
@@ -21,7 +21,14 @@ public class DistrictDTO {
     private List<@Valid District> districts;
 
 
-    public static DistrictDTO parseToListDTO(List<District> districts){
+    /**
+     * Converte obejto para DTO
+     *
+     * @author Thomaz Ferreira
+     * @param districts
+     * @return DistrictDTO
+     */
+    public static DistrictDTO parseToDTO(List<District> districts){
         return DistrictDTO.builder().districts(districts).build();
     }
 }

--- a/src/main/java/com/meli/w4/desafio_quality/repository/DistrictRepository.java
+++ b/src/main/java/com/meli/w4/desafio_quality/repository/DistrictRepository.java
@@ -23,7 +23,7 @@ public class DistrictRepository {
      * @param districts
      * @throws IOException
      */
-    public static void serializaDistricts(List<District> districts) throws IOException {
+    public static void serializeDistricts(List<District> districts) throws IOException {
         try {
             ObjectMapper mapper = new ObjectMapper();
             mapper.writeValue(new File(JSON_FILE_NAME), districts);
@@ -40,7 +40,7 @@ public class DistrictRepository {
      * @return List
      * @throws IOException
      */
-    public static List<District> desserializaDistricts() throws IOException {
+    public static List<District> unserializeDistricts() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         List<District> listaBairros = new ArrayList<District>();

--- a/src/main/java/com/meli/w4/desafio_quality/service/DistrictService.java
+++ b/src/main/java/com/meli/w4/desafio_quality/service/DistrictService.java
@@ -24,8 +24,8 @@ public class DistrictService {
      * @param uri
      * @return ResponseEntity
      */
-    public ResponseEntity<Map<String, String>> gravaBairro(DistrictDTO districts, URI uri) throws IOException{
-        DistrictRepository.serializaDistricts(districts.getDistricts());
+    public ResponseEntity<Map<String, String>> saveDistricts(DistrictDTO districts, URI uri) throws IOException{
+        DistrictRepository.serializeDistricts(districts.getDistricts());
         Map<String, String> response = new HashMap<String, String>();
         response.put("status", "success");
         response.put("message", "Bairros cadastrados com sucesso");
@@ -39,7 +39,9 @@ public class DistrictService {
      * @author Thomaz Ferreira
      * @return ResponseEntity
      */
-    public ResponseEntity<List<District>> getAllDistricts() throws IOException {
-        return ResponseEntity.ok().body(DistrictRepository.desserializaDistricts());
+    public ResponseEntity<DistrictDTO> getAllDistricts() throws IOException {
+        List<District> unserializedDistrics = DistrictRepository.unserializeDistricts();
+        DistrictDTO dto = DistrictDTO.parseToListDTO(unserializedDistrics);
+        return ResponseEntity.ok().body(dto);
     }
 }

--- a/src/main/java/com/meli/w4/desafio_quality/service/DistrictService.java
+++ b/src/main/java/com/meli/w4/desafio_quality/service/DistrictService.java
@@ -41,7 +41,7 @@ public class DistrictService {
      */
     public ResponseEntity<DistrictDTO> getAllDistricts() throws IOException {
         List<District> unserializedDistrics = DistrictRepository.unserializeDistricts();
-        DistrictDTO dto = DistrictDTO.parseToListDTO(unserializedDistrics);
-        return ResponseEntity.ok().body(dto);
+        DistrictDTO unserializedDistricsDTO = DistrictDTO.parseToDTO(unserializedDistrics);
+        return ResponseEntity.ok().body(unserializedDistricsDTO);
     }
 }


### PR DESCRIPTION
Falaaaa rapaziada!

Seguinte, nessa PR eu ajustei o retorno do endpoint

```bash
/getDistricts
```

<br>

Na versão atual, esse endpoint está retornando só um array de objetos do tipo District( List<DistrictDTO> ), conforme o exemplo abaixo:

```JSON
{
    [
        {
            "name": "Bairro 1"
        },
        {
            "name": "Bairro 2"
        },
        {
            "name": "Bairro 3"
        }
    ]
}
```

<br>

Na alteração que fiz, o retorno está sendo um objeto de listas do tipo District, de forma a melhorar a compreensão do retorno da requisição. Após a alteração, o response ficará assim:

```JSON
{
    "districts": [
        {
            "name": "Bairro 1"
        },
        {
            "name": "Bairro 2"
        },
        {
            "name": "Bairro 3"
        }
    ]
}
```

<br>
A outra alteração que fiz foi só mudar os nomes das funções e atributos que desenvolvi nessa feature para inglês. Assim o código ficará no padrão combinado entre nós.
<br><br>

É isso galerinha!
Valeeeuuu!